### PR TITLE
`ProductScreenActivity` renamed to `AddProductActivity`.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:theme="@style/Theme.Genki"
         tools:targetApi="31">
         <activity
-            android:name=".ui.activities.ProductScreenActivity"
+            android:name=".ui.activities.AddProductActivity"
             android:label="@string/product_screen_title"
             android:exported="false">
             <meta-data

--- a/app/src/main/java/com/theroughstallions/genki/ui/activities/AddProductActivity.kt
+++ b/app/src/main/java/com/theroughstallions/genki/ui/activities/AddProductActivity.kt
@@ -5,10 +5,10 @@ import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import com.theroughstallions.genki.R
 
-class ProductScreenActivity : AppCompatActivity() {
+class AddProductActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_product_screen)
+        setContentView(R.layout.activity_add_product)
 
         val actionBar = supportActionBar
         actionBar?.setDisplayHomeAsUpEnabled(true)

--- a/app/src/main/res/layout/activity_add_product.xml
+++ b/app/src/main/res/layout/activity_add_product.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.activities.ProductScreenActivity">
+    tools:context=".ui.activities.AddProductActivity">
 
     <TextView
         android:id="@+id/itemNameTextView"


### PR DESCRIPTION
As posted in Jira, this change was done to make the name more concise and more direct as to what the activity does. The new name will make it more clear just in the event we add a product screen that lists products the user is looking to select or add.